### PR TITLE
PEX issues #335

### DIFF
--- a/addrbook.go
+++ b/addrbook.go
@@ -368,6 +368,12 @@ func (a *AddrBook) loadFromFile(filePath string) bool {
 	return true
 }
 
+// Save saves the book.
+func (a *AddrBook) Save() {
+	log.Info("Saving AddrBook to file", "size", a.Size())
+	a.saveToFile(a.filePath)
+}
+
 /* Private methods */
 
 func (a *AddrBook) saveRoutine() {

--- a/addrbook.go
+++ b/addrbook.go
@@ -153,6 +153,7 @@ func (a *AddrBook) OurAddresses() []*NetAddress {
 	return addrs
 }
 
+// NOTE: addr must not be nil
 func (a *AddrBook) AddAddress(addr *NetAddress, src *NetAddress) {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()

--- a/pex_reactor.go
+++ b/pex_reactor.go
@@ -42,12 +42,14 @@ func NewPEXReactor(book *AddrBook) *PEXReactor {
 
 func (pexR *PEXReactor) OnStart() error {
 	pexR.BaseReactor.OnStart()
+	pexR.book.OnStart()
 	go pexR.ensurePeersRoutine()
 	return nil
 }
 
 func (pexR *PEXReactor) OnStop() {
 	pexR.BaseReactor.OnStop()
+	pexR.book.OnStop()
 }
 
 // Implements Reactor

--- a/pex_reactor.go
+++ b/pex_reactor.go
@@ -130,16 +130,6 @@ func (pexR *PEXReactor) SendAddrs(peer *Peer, addrs []*NetAddress) {
 	peer.Send(PexChannel, struct{ PexMessage }{&pexAddrsMessage{Addrs: addrs}})
 }
 
-// SaveAddrBook saves underlying address book
-func (r *PEXReactor) SaveAddrBook() {
-	r.book.Save()
-}
-
-// AddPeerAddress adds raw NetAddress to the address book
-func (r *PEXReactor) AddPeerAddress(peerAddr, srcAddr *NetAddress) {
-	r.book.AddAddress(peerAddr, srcAddr)
-}
-
 // Ensures that sufficient peers are connected. (continuous)
 func (pexR *PEXReactor) ensurePeersRoutine() {
 	// Randomize when routine starts

--- a/pex_reactor.go
+++ b/pex_reactor.go
@@ -130,6 +130,16 @@ func (pexR *PEXReactor) SendAddrs(peer *Peer, addrs []*NetAddress) {
 	peer.Send(PexChannel, struct{ PexMessage }{&pexAddrsMessage{Addrs: addrs}})
 }
 
+// SaveAddrBook saves underlying address book
+func (r *PEXReactor) SaveAddrBook() {
+	r.book.Save()
+}
+
+// AddPeerAddress adds raw NetAddress to the address book
+func (r *PEXReactor) AddPeerAddress(peerAddr, srcAddr *NetAddress) {
+	r.book.AddAddress(peerAddr, srcAddr)
+}
+
 // Ensures that sufficient peers are connected. (continuous)
 func (pexR *PEXReactor) ensurePeersRoutine() {
 	// Randomize when routine starts

--- a/pex_reactor.go
+++ b/pex_reactor.go
@@ -112,7 +112,9 @@ func (pexR *PEXReactor) Receive(chID byte, src *Peer, msgBytes []byte) {
 		// (We don't want to get spammed with bad peers)
 		srcAddr := src.Connection().RemoteAddress
 		for _, addr := range msg.Addrs {
-			pexR.book.AddAddress(addr, srcAddr)
+			if addr != nil {
+				pexR.book.AddAddress(addr, srcAddr)
+			}
 		}
 	default:
 		log.Warn(Fmt("Unknown message type %v", reflect.TypeOf(msg)))


### PR DESCRIPTION
This is a 2 PR change fixing https://github.com/tendermint/tendermint/issues/335

1 PR: https://github.com/tendermint/tendermint/pull/370

In this PR:
- 3 new API functions for `addrbook`
- starting/stopping the book inside the reactor, because the former is the main component of the latter and the reactor should be responsible for starting and stopping of its components