### PR TITLE
v0.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.swp
+*.swo
+*.bak
+.DS_Store
+vendor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,57 @@
+# Changelog
+
+## 0.4.0 (March 6, 2017)
+
+BREAKING CHANGES: 
+
+- DialSeeds now takes an AddrBook and returns an error: `DialSeeds(*AddrBook, []string) error`
+- NewNetAddressString now returns an error: `NewNetAddressString(string) (*NetAddress, error)`
+
+FEATURES:
+
+- `NewNetAddressStrings([]string) ([]*NetAddress, error)`
+- `AddrBook.Save()`
+
+IMPROVEMENTS:
+
+- PexReactor responsible for starting and stopping the AddrBook
+
+BUG FIXES:
+
+- DialSeeds returns an error instead of panicking on bad addresses
+
+## 0.3.5 (January 12, 2017)
+
+FEATURES
+
+- Toggle strict routability in the AddrBook 
+
+BUG FIXES
+
+- Close filtered out connections
+- Fixes for MakeConnectedSwitches and Connect2Switches
+
+## 0.3.4 (August 10, 2016)
+
+FEATURES:
+
+- Optionally filter connections by address or public key
+
+## 0.3.3 (May 12, 2016)
+
+FEATURES:
+
+- FuzzConn
+
+## 0.3.2 (March 12, 2016)
+
+IMPROVEMENTS:
+
+- Memory optimizations
+
+## 0.3.1 ()
+
+FEATURES: 
+
+- Configurable parameters
+

--- a/addrbook.go
+++ b/addrbook.go
@@ -153,6 +153,7 @@ func (a *AddrBook) OurAddresses() []*NetAddress {
 	return addrs
 }
 
+// NOTE: addr must not be nil
 func (a *AddrBook) AddAddress(addr *NetAddress, src *NetAddress) {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
@@ -366,6 +367,12 @@ func (a *AddrBook) loadFromFile(filePath string) bool {
 		}
 	}
 	return true
+}
+
+// Save saves the book.
+func (a *AddrBook) Save() {
+	log.Info("Saving AddrBook to file", "size", a.Size())
+	a.saveToFile(a.filePath)
 }
 
 /* Private methods */

--- a/addrbook.go
+++ b/addrbook.go
@@ -135,6 +135,9 @@ func (a *AddrBook) OnStart() error {
 
 func (a *AddrBook) OnStop() {
 	a.BaseService.OnStop()
+}
+
+func (a *AddrBook) Wait() {
 	a.wg.Wait()
 }
 

--- a/addrbook_test.go
+++ b/addrbook_test.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const addrBookStrict = true
@@ -38,7 +40,7 @@ func TestEmpty(t *testing.T) {
 	}
 }
 
-func randIPv4Address() *NetAddress {
+func randIPv4Address(t *testing.T) *NetAddress {
 	for {
 		ip := fmt.Sprintf("%v.%v.%v.%v",
 			rand.Intn(254)+1,
@@ -47,7 +49,8 @@ func randIPv4Address() *NetAddress {
 			rand.Intn(255),
 		)
 		port := rand.Intn(65535-1) + 1
-		addr := NewNetAddressString(fmt.Sprintf("%v:%v", ip, port))
+		addr, err := NewNetAddressString(fmt.Sprintf("%v:%v", ip, port))
+		assert.Nil(t, err, "error generating rand network address")
 		if addr.Routable() {
 			return addr
 		}
@@ -64,8 +67,8 @@ func TestSaveAddresses(t *testing.T) {
 		src  *NetAddress
 	}{}
 	for i := 0; i < 100; i++ {
-		addr := randIPv4Address()
-		src := randIPv4Address()
+		addr := randIPv4Address(t)
+		src := randIPv4Address(t)
 		randAddrs = append(randAddrs, struct {
 			addr *NetAddress
 			src  *NetAddress
@@ -118,8 +121,8 @@ func TestPromoteToOld(t *testing.T) {
 		src  *NetAddress
 	}{}
 	for i := 0; i < 100; i++ {
-		addr := randIPv4Address()
-		src := randIPv4Address()
+		addr := randIPv4Address(t)
+		src := randIPv4Address(t)
 		randAddrs = append(randAddrs, struct {
 			addr *NetAddress
 			src  *NetAddress

--- a/listener.go
+++ b/listener.go
@@ -70,7 +70,11 @@ func NewDefaultListener(protocol string, lAddr string, skipUPNP bool) Listener {
 	log.Info("Local listener", "ip", listenerIP, "port", listenerPort)
 
 	// Determine internal address...
-	var intAddr *NetAddress = NewNetAddressString(lAddr)
+	var intAddr *NetAddress
+	intAddr, err = NewNetAddressString(lAddr)
+	if err != nil {
+		PanicCrisis(err)
+	}
 
 	// Determine external address...
 	var extAddr *NetAddress

--- a/pex_reactor.go
+++ b/pex_reactor.go
@@ -42,12 +42,14 @@ func NewPEXReactor(book *AddrBook) *PEXReactor {
 
 func (pexR *PEXReactor) OnStart() error {
 	pexR.BaseReactor.OnStart()
+	pexR.book.OnStart()
 	go pexR.ensurePeersRoutine()
 	return nil
 }
 
 func (pexR *PEXReactor) OnStop() {
 	pexR.BaseReactor.OnStop()
+	pexR.book.OnStop()
 }
 
 // Implements Reactor
@@ -110,7 +112,9 @@ func (pexR *PEXReactor) Receive(chID byte, src *Peer, msgBytes []byte) {
 		// (We don't want to get spammed with bad peers)
 		srcAddr := src.Connection().RemoteAddress
 		for _, addr := range msg.Addrs {
-			pexR.book.AddAddress(addr, srcAddr)
+			if addr != nil {
+				pexR.book.AddAddress(addr, srcAddr)
+			}
 		}
 	default:
 		log.Warn(Fmt("Unknown message type %v", reflect.TypeOf(msg)))

--- a/pex_reactor.go
+++ b/pex_reactor.go
@@ -42,14 +42,14 @@ func NewPEXReactor(book *AddrBook) *PEXReactor {
 
 func (pexR *PEXReactor) OnStart() error {
 	pexR.BaseReactor.OnStart()
-	pexR.book.OnStart()
+	pexR.book.Start()
 	go pexR.ensurePeersRoutine()
 	return nil
 }
 
 func (pexR *PEXReactor) OnStop() {
 	pexR.BaseReactor.OnStop()
-	pexR.book.OnStop()
+	pexR.book.Stop()
 }
 
 // Implements Reactor

--- a/pex_reactor.go
+++ b/pex_reactor.go
@@ -64,7 +64,13 @@ func (pexR *PEXReactor) GetChannels() []*ChannelDescriptor {
 // Implements Reactor
 func (pexR *PEXReactor) AddPeer(peer *Peer) {
 	// Add the peer to the address book
-	netAddr := NewNetAddressString(peer.ListenAddr)
+	netAddr, err := NewNetAddressString(peer.ListenAddr)
+	if err != nil {
+		// this should never happen
+		log.Error("Error in AddPeer: invalid peer address", "addr", peer.ListenAddr, "error", err)
+		return
+	}
+
 	if peer.IsOutbound() {
 		if pexR.book.NeedMoreAddrs() {
 			pexR.RequestPEX(peer)
@@ -109,7 +115,6 @@ func (pexR *PEXReactor) Receive(chID byte, src *Peer, msgBytes []byte) {
 	default:
 		log.Warn(Fmt("Unknown message type %v", reflect.TypeOf(msg)))
 	}
-
 }
 
 // Asks peer for more addresses.

--- a/switch.go
+++ b/switch.go
@@ -296,20 +296,24 @@ func (sw *Switch) startInitPeer(peer *Peer) {
 	sw.addPeerToReactors(peer) // run AddPeer on each reactor
 }
 
-// Dial a list of seeds in random order
-// Spawns a go routine for each dial
-func (sw *Switch) DialSeeds(seeds []string) {
+// Dial a list of seeds asynchronously in random order
+func (sw *Switch) DialSeeds(seeds []string) error {
+
+	netAddrs, err := NewNetAddressStrings(seeds)
+	if err != nil {
+		return err
+	}
+
 	// permute the list, dial them in random order.
 	perm := rand.Perm(len(seeds))
 	for i := 0; i < len(perm); i++ {
 		go func(i int) {
 			time.Sleep(time.Duration(rand.Int63n(3000)) * time.Millisecond)
 			j := perm[i]
-			addr := NewNetAddressString(seeds[j])
-
-			sw.dialSeed(addr)
+			sw.dialSeed(netAddrs[j])
 		}(i)
 	}
+	return nil
 }
 
 func (sw *Switch) dialSeed(addr *NetAddress) {

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package p2p
 
-const Version = "0.3.5" // minor fixes
+const Version = "0.4.0" // DialSeeds returns an error


### PR DESCRIPTION
# Breaking

- DialSeeds signature is now `DialSeeds(*AddrBook, []string) error`
- NewNetAddressString signature is now `NewNetAddressString(string) (*NetAddress, error)`

# Details

- DialSeeds:
  - Proper error handling
  - Takes an AddrBook argument and adds all seeds to it

- AddrBook:
  - PexReactor starts and stops it
  - Save method